### PR TITLE
Fix script for checking the status of OpenAI batches

### DIFF
--- a/benchmark/check_open_ai_batches.py
+++ b/benchmark/check_open_ai_batches.py
@@ -29,11 +29,16 @@ if __name__ == "__main__":
         metadata = Batch.model_validate_json(batch_job_metadata.read_text())
         batch = client.batches.retrieve(metadata.id)
 
+        # Note: When the status is "validating", the batch.request_counts.total is 0.
         completed_progress = (
-            f"{batch.request_counts.completed / batch.request_counts.total:.2%}" if batch.request_counts else None
+            f"{batch.request_counts.completed / batch.request_counts.total:.2%}"
+            if batch.request_counts and batch.request_counts.total > 0
+            else None
         )
         failed_progress = (
-            f"{batch.request_counts.failed / batch.request_counts.total:.2%}" if batch.request_counts else None
+            f"{batch.request_counts.failed / batch.request_counts.total:.2%}"
+            if batch.request_counts and batch.request_counts.total > 0
+            else None
         )
 
         if batch.status == "completed" and batch.error_file_id:
@@ -48,10 +53,10 @@ if __name__ == "__main__":
                 batch.output_file_id,
                 Text.assemble((batch.status, "bold red")),
                 Text.assemble((completed_progress, "green"))
-                if isinstance(completed_progress, str) and completed_progress != "0%"
+                if isinstance(completed_progress, str) and completed_progress != "0.00%"
                 else completed_progress,
                 Text.assemble((failed_progress, "red"))
-                if isinstance(failed_progress, str) and failed_progress != "0%"
+                if isinstance(failed_progress, str) and failed_progress != "0.00%"
                 else failed_progress,
                 error_file.name,
             )
@@ -61,10 +66,10 @@ if __name__ == "__main__":
                 batch.output_file_id,
                 Text.assemble((batch.status, "bold green")) if batch.status == "completed" else batch.status,
                 Text.assemble((completed_progress, "green"))
-                if isinstance(completed_progress, str) and completed_progress != "0%"
+                if isinstance(completed_progress, str) and completed_progress != "0.00%"
                 else completed_progress,
                 Text.assemble((failed_progress, "red"))
-                if isinstance(failed_progress, str) and failed_progress != "0%"
+                if isinstance(failed_progress, str) and failed_progress != "0.00%"
                 else failed_progress,
                 None,
             )


### PR DESCRIPTION
This PR fixes two things:
 
- It now accounts for when a batch's status is `"validating"` and computes the progress accordingly;
- It corrects the value used for comparison to decide whether to color the table numeric values.